### PR TITLE
[WIP] Notifications to users and the admin channel now have separate thresholds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 bin/settings.py
 bin/venv
 lambda.zip
-
+venv/
+.idea/

--- a/bin/notification.py
+++ b/bin/notification.py
@@ -31,8 +31,13 @@ class Notificator:
 
     def handle_single_event(self, body):
         query = AthenaQuery(**json.loads(body))
-        if query.data_scanned > self.config.SLACK_ALERT_DATA_THRESHOLD:
-            self.send_slack_notification(query)
+        # alert may be sent either to the user who submitted the query or to the admin team channel, or to both
+        # here we decide where the notification is to be sent
+        # if at least one threshold is reached, we call the send function with params where the message is to be sent
+        is_send_to_user = query.data_scanned > self.config.SLACK_ALERT_DATA_USER_THRESHOLD
+        is_send_to_admin_channel = query.data_scanned > self.config.SLACK_ALERT_DATA_CHANNEL_THRESHOLD
+        if is_send_to_user or is_send_to_admin_channel:
+            self.send_slack_notification(query, is_send_to_user, is_send_to_admin_channel)
 
     def send_slack_to_channel(self, text):
         requests.post(self.config.SLACK_WEBHOOK_URL, json={'text': text, 'link_names': 1})
@@ -59,7 +64,7 @@ class Notificator:
             logging.error(
                 f'Unexpected response code from slack api when opening conversation with user {user_id}: {response}')
 
-    def send_slack_notification(self, query):
+    def send_slack_notification(self, query, is_send_to_user=True, is_send_to_admin_channel=True):
         slack_user = None
         if hasattr(self.config, 'SLACK_USER_MAPPINGS'):
             slack_user = self.config.SLACK_USER_MAPPINGS.get(query.executing_user)
@@ -71,9 +76,9 @@ class Notificator:
         )
 
         text = self.config.SLACK_MESSAGE.format(**params)
-
-        self.send_slack_to_channel(text)
-        if slack_user:
+        if is_send_to_admin_channel:
+            self.send_slack_to_channel(text)
+        if slack_user and is_send_to_user:
             self.send_slack_to_user(slack_user, text)
         else:
             logger.warning(f'Couldn\'t find slack user mapping for user {query.executing_user}')

--- a/bin/settings.py.template
+++ b/bin/settings.py.template
@@ -10,8 +10,11 @@ SLACK_BOT_TOKEN = ''
 #    'example_aws_user': 'IDXXXXXX'
 # }
 
-# Data scanned byte threshold above which to send notifications to users
-SLACK_ALERT_DATA_THRESHOLD = 100*1024*1024*1024
+# Data scanned byte threshold above which to send notifications to the user who submitted the query
+SLACK_ALERT_DATA_USER_THRESHOLD = 100*1024*1024*1024
+
+# Data scanned byte threshold above which to send notifications to the admin team channel
+SLACK_ALERT_DATA_CHANNEL_THRESHOLD = 4 * SLACK_ALERT_DATA_USER_THRESHOLD
 
 # Slack message to be sent
 SLACK_MESSAGE = '{user} your last query scanned {data_scanned_gb} GB'

--- a/bin/tests/test_notification.py
+++ b/bin/tests/test_notification.py
@@ -21,7 +21,8 @@ class NotificatorTest(unittest.TestCase):
     def test_handle_batch_event(self, requests):
 
         config = Mock()
-        config.SLACK_ALERT_DATA_THRESHOLD = 100
+        config.SLACK_ALERT_DATA_USER_THRESHOLD = 100
+        config.SLACK_ALERT_DATA_CHANNEL_THRESHOLD = 400
         config.SLACK_USER_MAPPINGS = {'test': 'mapped_user'}
         config.SLACK_MESSAGE = 'test message'
         config.SLACK_WEBHOOK_URL = 'url'


### PR DESCRIPTION
Submitting all notifications to the admin channel causes the channel to be flooded with notifications. The change allows setting a higher threshold for the notifications being sent to the admin channel.