### PR TITLE
DE-4537 Anomaly detection in cloudwatch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,4 +5,4 @@ upload_lambda: zip_lambda
 	aws s3 cp lambda.zip "s3://$(LAMBDA_BUCKET)/$(LAMBDA_KEY)"
 
 run_cloudformation: upload_lambda
-	aws cloudformation create-stack --capabilities CAPABILITY_IAM --stack-name AthenaAlerter --template-body file://cloudformation/cf.yaml --parameters ParameterKey=CloudtrailBucket,ParameterValue=$(CLOUDTRAIL_BUCKET) ParameterKey=LambdaS3Bucket,ParameterValue=$(LAMBDA_BUCKET) ParameterKey=LambdaS3Key,ParameterValue=$(LAMBDA_KEY) ParameterKey=DynamoDBTableName,ParameterValue=$(DYNAMODB_TABLE_NAME) ParameterKey=SQSQueueName,ParameterValue=$(SQS_QUEUE_NAME)
+	aws cloudformation create-stack --capabilities CAPABILITY_IAM --stack-name AthenaAlerter --template-body file://cloudformation/cf.yaml --parameters ParameterKey=CloudtrailBucket,ParameterValue=$(CLOUDTRAIL_BUCKET) ParameterKey=LambdaS3Bucket,ParameterValue=$(LAMBDA_BUCKET) ParameterKey=LambdaS3Key,ParameterValue=$(LAMBDA_KEY) ParameterKey=DynamoDBTableName,ParameterValue=$(DYNAMODB_TABLE_NAME) ParameterKey=SQSQueueName,ParameterValue=$(SQS_QUEUE_NAME) ParameterKey=SNSAnomalyDetectionTopicName,ParameterValue=$(SQS_ANOMALY_DETECTION_TOPIC_NAME)

--- a/Readme.md
+++ b/Readme.md
@@ -35,6 +35,7 @@ To deploy Athena Alerter:
     - CLOUDTRAIL_BUCKET - name of s3 bucket in which to store cloudtrail logs. This bucket should not exist and will be created for you,
     - DYNAMODB_TABLE_NAME - name of dynamodb table which will be used for storing query data. The table should not exist and will be created for you. The name needs to match the QUERIES_TABLE parameter from settings.py,
     - SQS_QUEUE_NAME - name of sqs queue used for query finished events. The queue should not exists and will be created for you. The name needs to match the SQS_QUEUE_URL parameter from settings.py.
+    - SQS_ANOMALY_DETECTION_TOPIC_NAME - name to which cloudwatch pushes events about anomaly detection in query sizes. This value is used to connect the topic as input to notifier lambda function (setting metrics is done separately in terraform) - see anomaly detection section below
     
 Note that S3 bucket names need to be globally unique (that means for all aws accounts).
     
@@ -42,7 +43,7 @@ Sample deployment:
 ```
 cp bin/settings.py.template bin/settings.py
 vi settings.py # Or use any other editor and provide configuration
-make LAMBDA_BUCKET=myorg-code-bucket LAMBDA_KEY=lambda/athena_alerter.zip CLOUDTRAIL_BUCKET=myorg-cloudtrail DYNAMODB_TABLE_NAME=athena_queries SQS_QUEUE_NAME=athena_queries run_cloudformation 
+make LAMBDA_BUCKET=myorg-code-bucket LAMBDA_KEY=lambda/athena_alerter.zip CLOUDTRAIL_BUCKET=myorg-cloudtrail DYNAMODB_TABLE_NAME=athena_queries SQS_QUEUE_NAME=athena_queries SQS_ANOMALY_DETECTION_TOPIC_NAME=athena_alerter_anomaly_detection run_cloudformation 
 
 ```
 
@@ -66,3 +67,13 @@ The tool consist of three lambda functions:
 - notification - this function runs for each sqs event, checks whether the amount of data scanned exceeded the notification threshold and if so, generates a slack message. If you want to process the data scanned information differently, this function can be easily replaced with your own implementation.
 
 Note that because of the nature of cloudtrail log processing, notifications arrive a few minutes after the actual query has started.
+
+# Anomaly detection 
+
+Apart from the basic functionality described above, Athena Alerter may also be used in combination with Cloudwatch for notifying users about abnormally large queries.
+Cloudwatch Metrics and Cloudwatch Anomaly Detection Alerts are used in this scenario.
+You mat switch on/off this using Anomaly Detection with USE_CLOUDWATCH_ANOMALY_DETECTION switch in settings.py.
+When set to true, UsageUpdater reports all finished queries to Cloudwatch as metrics.
+Next, in cloudwatch we need to create anomaly detection alerts on these metrics (one alert per user).
+The alerts may be created using using files in terraform directory (see readme file there).
+Finally, when Cloudwatch will start sending anomaly detection messages to appropriate queue, an AnomalyDetectionNotificator class in notification.py will handle these messages and send appropriate notifications to slack.

--- a/bin/cloudwatch_metrics.py
+++ b/bin/cloudwatch_metrics.py
@@ -1,0 +1,37 @@
+import boto3
+import settings
+
+"""
+This class sends metrics about finished athena queryies to cloudwatch
+"""
+class CloudwatchMetrics:
+
+    cloudwatch = boto3.client('cloudwatch')
+
+    @classmethod
+    def report_query_metric(cls, metric_value, user):
+        """
+        Send metric to cloudwatch about the scanned size for the particular query
+        You just need to submit scanned size and the name of the user, who submitted the query
+        """
+        metric_data = cls._prepare_metric_dict(metric_value, user)
+        cls.cloudwatch.put_metric_data(
+            MetricData=metric_data,
+            Namespace=settings.CLOUDWATCH_METRIC_NAMESPACE
+        )
+
+    @classmethod
+    def _prepare_metric_dict(cls, value, user):
+        return [
+            {
+                'MetricName': settings.CLOUDWATCH_METRIC_NAME,
+                'Dimensions': [
+                    {
+                        'Name': 'athena_user',
+                        'Value': user
+                    },
+                ],
+                'Unit': 'Bytes',
+                'Value': value
+            },
+        ]

--- a/bin/model.py
+++ b/bin/model.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from enum import Enum
+import json
 
 TIMESTAMP_FORMAT = '%Y-%m-%d %H:%M:%S'
 
@@ -20,3 +21,43 @@ class AthenaQuery:
     executing_user: str
     data_scanned: int = 0
     query_sql: str = None
+
+@dataclass
+class AnomalyDetectionEvent:
+    """
+    dataclass corresponding to a sns message about anomaly detection from cloudwatch
+    should match also other sns messages
+    """
+    EventSource: str
+    EventVersion: str
+    EventSubscriptionArn: str
+    Sns: dict
+
+@dataclass
+class AnomalyDetectionSns:
+    """
+    dataclass corresponding to a part of sns message about anomaly detection from cloudwatch
+    should match also other sns messages
+    """
+    Type: str
+    MessageId: str
+    TopicArn: str
+    Subject: str
+    Message: str
+    Timestamp: str
+    SignatureVersion: str
+    Signature: str
+    SigningCertUrl: str
+    UnsubscribeUrl: str
+    MessageAttributes: str
+
+class AnomalyDetectionMessage:
+    """
+    class corresponding to a part of sns message about anomaly detection from cloudwatch
+    this one is specific to our cloudwatch metric anomaly detection alerts
+    """
+    def __init__(self, message_json):
+        message = json.loads(message_json)
+        self.new_state_value = message['NewStateValue']
+        self.new_state_reason = message['NewStateReason']
+        self.user = dict([(i['name'], i['value']) for i in message['Trigger']['Dimensions']])['athena_user']

--- a/bin/notification.py
+++ b/bin/notification.py
@@ -107,9 +107,9 @@ class AnomalyDetectionNotificator(Notificator):
             user = message.user
             params = dict(subject=subject, user=user, new_state_reason=new_state_reason)
             text = self.config.SLACK_ANOMALY_DETECTION_THRESHOLD_MESSAGE.format(**params)
+            self.send_slack_to_channel(text)
             if hasattr(self.config, 'SLACK_USER_MAPPINGS'):
                 slack_user = self.config.SLACK_USER_MAPPINGS.get(user)
-            self.send_slack_to_channel(text)
             if not slack_user:
                 logger.warning(f'Couldn\'t find slack user mapping for user {user}')
             else:

--- a/bin/notification.py
+++ b/bin/notification.py
@@ -7,42 +7,65 @@ Currently only slack notifications are supported
 import json
 import logging
 from botocore.vendored import requests
+from abc import ABC, abstractmethod
 
 import settings
-from model import AthenaQuery, QueryState
+from model import AthenaQuery, AnomalyDetectionEvent, AnomalyDetectionMessage, AnomalyDetectionSns
 
 
 logger = logging.getLogger()
 
 def lambda_handler(event, context):
-    notificator = Notificator(config=settings)
-    notificator.handle_batch_event(event)
+    """
+    This lambda handler may be invoked by more than one events:
+    as of Jan 2020 its hard threshold notification or anomaly detection notification.
+    We have a simple logic which recognizes which event do we have at hand and we invoke an appropriate notifier
+    """
+    hard_threshold_notificator = HardThresholdNotificator(config=settings)
+    anomaly_detection_notificator = AnomalyDetectionNotificator(config=settings)
+    for record in event['Records']:
+        if is_hard_threshold_event(record):
+            anomaly_detection_notificator.handle_single_event(record=record)
+        elif is_anomaly_detecion_alert_event(record):
+            hard_threshold_notificator.handle_single_event(body=record['body'])
+        else:
+            logging.error("ERROR! Unknown event type!")
+            logging.debug(json.dumps(event))
+            raise Exception("ERROR! Unknown event type!")
+
+def is_anomaly_detecion_alert_event(record):
+    return 'EventSubscriptionArn' in record and 'anomaly_detection' in str.lower(record['EventSubscriptionArn'])
+
+def is_hard_threshold_event(record):
+    return 'eventSourceARN' in record and 'athena-queries' in record['eventSourceARN']
 
 
-class Notificator:
+class Notificator(ABC):
+    """
+    Abstract class sharing common methods for different notifier classes.
+    Handles incoming queue messages and sends slack notifications to appropriate users/channels when applicable
+    """
 
     def __init__(self, config):
         self.config = config
 
-    def handle_batch_event(self, event):
-        # actually SQS should be configured to always provide a single event, hence no extra try/catch between records
-        for record in event['Records']:
-            self.handle_single_event(body=record['body'])
-
-    def handle_single_event(self, body):
-        query = AthenaQuery(**json.loads(body))
-        # alert may be sent either to the user who submitted the query or to the admin team channel, or to both
-        # here we decide where the notification is to be sent
-        # if at least one threshold is reached, we call the send function with params where the message is to be sent
-        is_send_to_user = query.data_scanned > self.config.SLACK_ALERT_DATA_USER_THRESHOLD
-        is_send_to_admin_channel = query.data_scanned > self.config.SLACK_ALERT_DATA_CHANNEL_THRESHOLD
-        if is_send_to_user or is_send_to_admin_channel:
-            self.send_slack_notification(query, is_send_to_user, is_send_to_admin_channel)
+    @abstractmethod
+    def handle_single_event(self, record):
+        """
+        main queue record handling needs to be implemented here
+        """
+        pass
 
     def send_slack_to_channel(self, text):
+        """
+        Sends slack notification to a channel defined in config
+        """
         requests.post(self.config.SLACK_WEBHOOK_URL, json={'text': text, 'link_names': 1})
 
     def send_slack_to_user(self, user_id, text):
+        """
+        Sends slack notification to the user with submitted user_id
+        """
         response = requests.post('https://slack.com/api/conversations.open',
                                  headers={'Authorization': f'Bearer {self.config.SLACK_BOT_TOKEN}'},
                                  json={'users': user_id})
@@ -64,6 +87,60 @@ class Notificator:
             logging.error(
                 f'Unexpected response code from slack api when opening conversation with user {user_id}: {response}')
 
+
+class AnomalyDetectionNotificator(Notificator):
+    """
+    Handles messages form CloudWatch about abnormally large (for the given user) athena queries
+    """
+
+    def __init__(self, config):
+        self.config = config
+
+    def handle_single_event(self, record):
+        event = AnomalyDetectionEvent(**record)
+        record_sns = AnomalyDetectionSns(**event.Sns)
+        subject = record_sns.Subject
+        message = AnomalyDetectionMessage(record_sns.Message)
+        new_state_value = message.new_state_value
+        if str.lower(new_state_value) == 'alarm':
+            new_state_reason = message.new_state_reason
+            user = message.user
+            params = dict(subject=subject, user=user, new_state_reason=new_state_reason)
+            text = self.config.SLACK_ANOMALY_DETECTION_THRESHOLD_MESSAGE.format(**params)
+            if hasattr(self.config, 'SLACK_USER_MAPPINGS'):
+                slack_user = self.config.SLACK_USER_MAPPINGS.get(user)
+            self.send_slack_to_channel(text)
+            if not slack_user:
+                logger.warning(f'Couldn\'t find slack user mapping for user {user}')
+            else:
+                self.send_slack_to_user(slack_user, text)
+
+class HardThresholdNotificator(Notificator):
+    """
+    Handles notifications that an athena query has ended.
+    Events for all finished athena queries are submitted here.
+    The class checks if scanned size thresholds are crossed and, if so, send appropriate notifications to slack.
+    There are separate notifications for user and for the admin channel
+    """
+
+    def __init__(self, config):
+        self.config = config
+
+    def handle_batch_event(self, event):
+        # actually SQS should be configured to always provide a single event, hence no extra try/catch between records
+        for record in event['Records']:
+            self.handle_single_event(body=record['body'])
+
+    def handle_single_event(self, body):
+        query = AthenaQuery(**json.loads(body))
+        # alert may be sent either to the user who submitted the query or to the admin team channel, or to both
+        # here we decide where the notification is to be sent
+        # if at least one threshold is reached, we call the send function with params where the message is to be sent
+        is_send_to_user = query.data_scanned > self.config.SLACK_ALERT_DATA_USER_THRESHOLD
+        is_send_to_admin_channel = query.data_scanned > self.config.SLACK_ALERT_DATA_CHANNEL_THRESHOLD
+        if is_send_to_user or is_send_to_admin_channel:
+            self.send_slack_notification(query, is_send_to_user, is_send_to_admin_channel)
+
     def send_slack_notification(self, query, is_send_to_user=True, is_send_to_admin_channel=True):
         slack_user = None
         if hasattr(self.config, 'SLACK_USER_MAPPINGS'):
@@ -75,7 +152,7 @@ class Notificator:
             user = query.executing_user
         )
 
-        text = self.config.SLACK_MESSAGE.format(**params)
+        text = self.config.SLACK_HARD_THRESHOLD_MESSAGE.format(**params)
         if is_send_to_admin_channel:
             self.send_slack_to_channel(text)
         if not slack_user:
@@ -83,4 +160,3 @@ class Notificator:
         else:
             if is_send_to_user:
                 self.send_slack_to_user(slack_user, text)
-

--- a/bin/settings.py.template
+++ b/bin/settings.py.template
@@ -16,8 +16,11 @@ SLACK_ALERT_DATA_USER_THRESHOLD = 100*1024*1024*1024
 # Data scanned byte threshold above which to send notifications to the admin team channel
 SLACK_ALERT_DATA_CHANNEL_THRESHOLD = 4 * SLACK_ALERT_DATA_USER_THRESHOLD
 
-# Slack message to be sent
-SLACK_MESSAGE = '{user} your last query scanned {data_scanned_gb} GB'
+# Slack message to be sent when hard threshold is crossed (the one specified in SLACK_ALERT_DATA_USER_THRESHOLD or SLACK_ALERT_DATA_CHANNEL_THRESHOLD)
+SLACK_HARD_THRESHOLD_MESSAGE = '{user} your last query scanned {data_scanned_gb} GB'
+# Slack message to be sent when anomaly detection alerted about abnormally large query
+SLACK_ANOMALY_DETECTION_THRESHOLD_MESSAGE = '{subject}. User {user} issued an Athena query with a suspiciously large scanned volume: {new_state_reason}'
+
 
 # SQS queue url i.e. https://sqs.us-east-1.amazonaws.com/123456789012/athena-queries - note that you need to specify
 # this before that queue has been actually created. If in doubt you can always leave it empty and then update in
@@ -38,3 +41,10 @@ QUERIES_TABLE = 'athena_queries'
 #         m = re.search('{\"user\":\"([^\"]*)\".*', split[1])
 #         return m.group(1) if m is not None else None
 # USER_MAPPING_FUNCTION = mode_detect_user
+
+# If true, each query scanned size is to be sent to Cloudwatch as a metric
+USE_CLOUDWATCH_ANOMALY_DETECTION = True
+# name of the cloudwatch metric namespace to be submitted to cloudwatch
+CLOUDWATCH_METRIC_NAMESPACE = 'athena_alerter'
+# name of the metric to be submitted to cloudwatch
+CLOUDWATCH_METRIC_NAME = 'athena_alerter_bytes_scanned_test'

--- a/bin/tests/fixtures/anomaly_detection_sns.json
+++ b/bin/tests/fixtures/anomaly_detection_sns.json
@@ -1,0 +1,18 @@
+{
+    "EventSource": "aws:sns",
+    "EventVersion": "1.0",
+    "EventSubscriptionArn": "arn:aws:sns:us-east-1:170047911957:athena_alerter_anomaly_detection_test:bd5aff0b-7646-4c6d-a892-e10eb29e451d",
+    "Sns": {
+        "Type": "Notification",
+        "MessageId": "e38ca9e2-727f-53c4-a623-ff6b149705b1",
+        "TopicArn": "arn:aws:sns:us-east-1:170047911957:athena_alerter_anomaly_detection_test",
+        "Subject": "ALARM: \"athena_alerter_anomaly_detection_jacek_test\" in US East (N. Virginia)",
+        "Message": "{\"AlarmName\":\"athena_alerter_anomaly_detection_jacek_test\",\"AlarmDescription\":\"todelete\",\"AWSAccountId\":\"170047911957\",\"NewStateValue\":\"ALARM\",\"NewStateReason\":\"Threshold Crossed: 1 out of the last 1 datapoints [1.00000002E8 (03/01/20 15:53:00)] was greater than the threshold (10000.0) (minimum 1 datapoint for OK -> ALARM transition).\",\"StateChangeTime\":\"2020-01-03T15:58:32.049+0000\",\"Region\":\"US East (N. Virginia)\",\"OldStateValue\":\"INSUFFICIENT_DATA\",\"Trigger\":{\"MetricName\":\"athena_alerter_bytes_scanned_test\",\"Namespace\":\"athena_alerter\",\"StatisticType\":\"Statistic\",\"Statistic\":\"MAXIMUM\",\"Unit\":null,\"Dimensions\":[{\"value\":\"test\",\"name\":\"athena_user\"}],\"Period\":300,\"EvaluationPeriods\":1,\"ComparisonOperator\":\"GreaterThanThreshold\",\"Threshold\":10000.0,\"TreatMissingData\":\"- TreatMissingData:                    missing\",\"EvaluateLowSampleCountPercentile\":\"\"}}",
+        "Timestamp": "2020-01-03T15:58:32.103Z",
+        "SignatureVersion": "1",
+        "Signature": "OIB61dgWDmRO2SsLPKZsA8ZY+wT9LERKzg5xfVE/W6LbSs2IbF5hIJJdFDZgN10ZYe4K/xcTfwdwpcyk5VKAWHEBeWLBwdiya4wxM0u6YOCZwEWb1TlrZwk8azLxqCajPlXgkoyzw3JsHsLmXeuPpaTg+jYf0P7cPLeY/UIxcYL3VH2d7BkT14iwyjy7FijEfVsfphfTkC298Q8GbjjOD4hVtT1TypiyP+Ltg6+owv/Hd60WbZvd5jfRjaf0X1tnvrzW59AmMSs3bhE45ovvQGjzaVXchHVMZEmWGq11w2HgSFRTjt/o+04un+UUJg6O7Z+v8SNmI276FFYVLHF0Gw==",
+        "SigningCertUrl": "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-6aad65c2f9911b05cd53efda11f913f9.pem",
+        "UnsubscribeUrl": "https://sns.us-east-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:us-east-1:170047911957:athena_alerter_anomaly_detection_test:bd5aff0b-7646-4c6d-a892-e10eb29e451d",
+        "MessageAttributes": {}
+    }
+}

--- a/bin/usage_update.py
+++ b/bin/usage_update.py
@@ -19,25 +19,19 @@ def lambda_handler(event, context):
     athena = boto3.client('athena')
     sqs = boto3.client('sqs')
     dynamodb = boto3.resource('dynamodb')
-    if settings.USE_CLOUDWATCH_ANOMALY_DETECTION:
-        cloudwatch = boto3.client('cloudwatch')
-    else:
-        cloudwatch = None
-
     query_dao = QueryDao(settings, dynamodb)
 
-    updater = UsageUpdater(settings, query_dao, athena, sqs, cloudwatch)
+    updater = UsageUpdater(settings, query_dao, athena, sqs)
     updater.update_query_usage()
 
 
 class UsageUpdater:
 
-    def __init__(self, config, query_dao, athena, sqs, cloudwatch):
+    def __init__(self, config, query_dao, athena, sqs):
         self.config = config
         self.athena = athena
         self.sqs = sqs
         self.query_dao = query_dao
-        self.cloudwatch = cloudwatch
 
     def update_query_usage(self):
         queries = self.get_queries()

--- a/cloudformation/cf.yaml
+++ b/cloudformation/cf.yaml
@@ -15,6 +15,9 @@ Parameters:
   SQSQueueName:
     Type: String
     Description: Name of SQS queue with athena query events
+  SNSAnomalyDetectionTopicName:
+    Type: String
+    Description: Name of SNS queue with anomaly detection events
 Resources:
   QueriesDynamoDBTable:
     Type: 'AWS::DynamoDB::Table'
@@ -114,6 +117,10 @@ Resources:
       MessageRetentionPeriod: '345600'
       ReceiveMessageWaitTimeSeconds: '0'
       VisibilityTimeout: '30'
+  AthenaAnomalyDetectionQueue:
+    Type: 'AWS::SNS::Topic'
+    Properties:
+      TopicName: !Ref SNSAnomalyDetectionTopicName
   LambdaExecutionRole:
     Type: 'AWS::IAM::Role'
     Properties:
@@ -236,11 +243,21 @@ Resources:
       SourceArn: !GetAtt
         - ScheduledRule
         - Arn
-  EventSourceMapping:
+  EventSourceMappingNotifierHardThreshold:
     Type: 'AWS::Lambda::EventSourceMapping'
     Properties:
       EventSourceArn: !GetAtt
         - AthenaQueriesQueue
+        - Arn
+      FunctionName: !GetAtt
+        - NotificationLambda
+        - Arn
+      BatchSize: 1
+  EventSourceMappingNotifierAnomalyDetection:
+    Type: 'AWS::Lambda::EventSourceMapping'
+    Properties:
+      EventSourceArn: !GetAtt
+        - AthenaAnomalyDetectionQueue
         - Arn
       FunctionName: !GetAtt
         - NotificationLambda

--- a/terraform/Readme.md
+++ b/terraform/Readme.md
@@ -1,0 +1,33 @@
+Anomaly detection terraform
+================
+
+In this directory there are some resources for generating anomaly detection alerts on Cloudwatch using metrics submitted to Cloudwatch by Athena Alerter.
+
+## Metrics
+
+The metrics, which we want to use, need to have athena_user dimension and scanned bytes counts as values.
+They need to be submitted to the cloudwatch, e.g. by usage_updater script.
+
+## Terraform file
+
+We need to create a separate anomaly detection alert per user (athena_user is the dimension in the metric).
+Terraform 11 does not support loops, so we generate the final terraform file using python and Jinja2 template.
+In file anomaly_detection.template you can find a Jinja2 template with appropriate instructions, including loop over submitted users list.
+
+The template is filled using `generate_metrics_for_multiple_users.py`.
+The users list is read from `users.lst` file.
+If users.lst file is up to date, all you need to do is to run `generate_metrics_for_multiple_users.py` script, which will generate the final terraform file.
+The script has several parameters, which have default values, but may also be overwritten as cmd params.
+The explanation of these params is stored in the script. 
+Use --help switch to see the available params.
+
+
+Later, you just need to apply the terraform in a regular way: 
+
+```
+terraform plan
+terraform apply
+```
+
+This should create all the necessary alerts in terraform. 
+Please note that for some time (days, maybe even weeks) these alerts may be inactive due to insufficient data (see cloudwatch alerts console to see the status of different alerts).

--- a/terraform/anomaly_detection.template
+++ b/terraform/anomaly_detection.template
@@ -1,0 +1,41 @@
+provider "aws" {
+  profile    = "default"
+  region     = "us-east-1"
+}
+
+{% for user in users %}
+
+resource "aws_cloudwatch_metric_alarm" "slack_terraform_anomaly_detection_{{ user | replace(".", "_") | replace("@", "_at_") }}" {
+  alarm_name                = "slack_terraform_anomaly_detection_{{ user }}"
+  comparison_operator       = "GreaterThanUpperThreshold"
+  evaluation_periods        = "1"
+  threshold_metric_id       = "e1"
+  alarm_description         = "This metric monitors scanned size of athena query for user {{ user }}"
+  insufficient_data_actions = []
+  alarm_actions             = ["{{ alert_sns_queue_arn }}"]
+
+  metric_query {
+    id          = "e1"
+    expression  = "ANOMALY_DETECTION_BAND(m1)"
+    label       = "Scanned size"
+    return_data = "true"
+  }
+
+  metric_query {
+    id          = "m1"
+    return_data = "true"
+    metric {
+      metric_name = "{{ metric_name }}"
+      namespace   = "{{ namespace }}"
+      period      = "120"
+      stat        = "Maximum"
+      unit        = "Count"
+
+      dimensions = {
+        athena_user = "{{ user }}"
+      }
+    }
+  }
+}
+
+{% endfor %}

--- a/terraform/generate_metrics_for_multiple_users.py
+++ b/terraform/generate_metrics_for_multiple_users.py
@@ -1,0 +1,47 @@
+from jinja2 import Template
+import argparse
+
+"""
+This scripts generates a terraform file with multiple alerts, one alert per user in USERS_LIST_FILE.
+It works by filling jinja2 template with terraform instructions.
+The template contains loop instruction over the submitted users list
+"""
+
+# default values
+TEMPLATE_FILE = 'anomaly_detection.template'
+GENERATED_TERRAFORM_FILE_NAME = 'anomaly_detection.tf'
+USERS_LIST_FILE_NAME = 'users.lst'
+METRIC_NAME = 'athena_alerter_bytes_scanned_test'
+NAMESPACE = 'athena_alerter'
+ALERT_SNS_QUEUE_ARN = "arn:aws:sns:us-east-1:170047911957:athena_alerter_anomaly_detection_test"
+
+# you may override arguments with --option_name cmd params
+parser = argparse.ArgumentParser()
+parser.add_argument('--template_file', type=str, help='Where the file with Jinja2 template is stored')
+parser.add_argument('--generated_terraform_file_name', type=str, help='Where the generated final terraform file should be saved')
+parser.add_argument('--users_list_file_name', type=str, help='Name of the file with the lis tof users, for which we want to create metrics. One username a line')
+parser.add_argument('--metric_name', type=str, help='Name of the metric on the cloudwatch to be use as a base for the alarm')
+parser.add_argument('--namespace', type=str, help='Namespace of the metric on the cloudwatch to be use as a base for the alarm')
+parser.add_argument('--alert_sns_queue_arn', type=str, help='Where the anomaly detection messages are to be sent - name of SNS topic')
+
+args = parser.parse_args()
+if args.template_file:
+    TEMPLATE_FILE = args.template_file
+if args.generated_terraform_file_name:
+    GENERATED_TERRAFORM_FILE_NAME = args.generated_terraform_file_name
+if args.users_list_file_name:
+    USERS_LIST_FILE_NAME = args.users_list_file_name
+if args.metric_name:
+    METRIC_NAME = args.metric_name
+if args.namespace:
+    NAMESPACE = args.namespace
+if args.alert_sns_queue_arn:
+    ALERT_SNS_QUEUE_ARN = args.alert_sns_queue_arn
+
+
+users = [i.strip() for i in open(USERS_LIST_FILE_NAME).readlines()]
+fhin = open(TEMPLATE_FILE)
+template = Template(fhin.read())
+with open(GENERATED_TERRAFORM_FILE_NAME, 'w') as fhout:
+    fhout.write(template.render(users=users, metric_name=METRIC_NAME, namespace=NAMESPACE, alert_sns_queue_arn=ALERT_SNS_QUEUE_ARN))
+print('Terraform file generated, bye!')

--- a/terraform/users.lst
+++ b/terraform/users.lst
@@ -1,0 +1,1 @@
+put the list of users here, one name a line


### PR DESCRIPTION
* query scanned bytes numbers are sent to the couldwatch
* terraform file to generate cloudwatch anomaly detection metrics 
* there are now two possible slack notifiers
* notifier.py reads from two different sources - additional one is the anomaly detection queue