### PR TITLE
DE-9166 | Add query ID to Slack notification parameters

### DIFF
--- a/bin/notificators/hard_threshold_notificator.py
+++ b/bin/notificators/hard_threshold_notificator.py
@@ -46,7 +46,8 @@ class HardThresholdNotificator(Notificator):
             data_scanned_gb=int(query.data_scanned / (1024 * 1024 * 1024)),
             data_scanned_cost=round((query.data_scanned / (1024 * 1024 * 1024 * 1024)) * self.config.ATHENA_PRICE_PER_TB, 2),
             slack_user_id=slack_user,
-            user=query.executing_user
+            user=query.executing_user,
+            query_id=query.query_execution_id,
         )
         text = self.config.SLACK_HARD_THRESHOLD_MESSAGE.format(**params)
         text_additional_admin_main_channel = self.config.SLACK_HARD_THRESHOLD_MESSAGE_ADDITIONAL_ADMIN_MAIN_CHANNEL.format(**params)


### PR DESCRIPTION
So that we can use it to link the query later